### PR TITLE
fix: 修复@vue/compiler-sfc在部分场景导入错误

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,9 +1,9 @@
 import { fs } from 'zx';
 import { tsx } from '@ast-grep/napi';
-import sfc from '@vue/compiler-sfc';
+import { parse } from '@vue/compiler-sfc';
 
 function getScriptContentFromVue(filename: string) {
-  const { descriptor: result } = sfc.parse(fs.readFileSync(filename, 'utf-8'));
+  const { descriptor: result } = parse(fs.readFileSync(filename, 'utf-8'));
   const { script, scriptSetup } = result;
   const scriptNode = script || scriptSetup;
   return scriptNode?.content;


### PR DESCRIPTION
部分场景下，会出现这个错误，这里做了修复。
<img width="1087" alt="image" src="https://github.com/emosheeep/circular-dependency-scanner/assets/28132598/a9635a0a-230e-4277-8de0-2ad03dbe1630">
